### PR TITLE
CLOUD-1332 Fix web terminal arrow key audit handling

### DIFF
--- a/backend/localcommand/local_command_unix.go
+++ b/backend/localcommand/local_command_unix.go
@@ -1,9 +1,13 @@
+//go:build !windows
 // +build !windows
 
 package localcommand
 
 import (
+	"log"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"syscall"
 	"time"
 	"unsafe"
@@ -27,13 +31,25 @@ type LocalCommand struct {
 	cmd       *exec.Cmd
 	pty       pty.Pty
 	ptyClosed chan struct{}
+	auditFile string
 }
 
 func New(command string, argv []string, options ...Option) (*LocalCommand, error) {
+	auditFile, err := createBashAuditFile(command, argv)
+	if err != nil {
+		return nil, err
+	}
+	if auditFile != "" {
+		argv = append([]string{"--rcfile", auditFile, "-i"}, argv...)
+	}
+
 	cmd := exec.Command(command, argv...)
 
 	pty, err := pty.Start(cmd)
 	if err != nil {
+		if auditFile != "" {
+			os.Remove(auditFile)
+		}
 		// todo close cmd?
 		return nil, errors.Wrapf(err, "failed to start command `%s`", command)
 	}
@@ -49,6 +65,7 @@ func New(command string, argv []string, options ...Option) (*LocalCommand, error
 		cmd:       cmd,
 		pty:       pty,
 		ptyClosed: ptyClosed,
+		auditFile: auditFile,
 	}
 
 	for _, option := range options {
@@ -60,6 +77,9 @@ func New(command string, argv []string, options ...Option) (*LocalCommand, error
 	go func() {
 		defer func() {
 			lcmd.pty.Close()
+			if lcmd.auditFile != "" {
+				os.Remove(lcmd.auditFile)
+			}
 			close(lcmd.ptyClosed)
 		}()
 
@@ -67,6 +87,60 @@ func New(command string, argv []string, options ...Option) (*LocalCommand, error
 	}()
 
 	return lcmd, nil
+}
+
+func createBashAuditFile(command string, argv []string) (string, error) {
+	if !isPlainBashCommand(command, argv) {
+		return "", nil
+	}
+
+	file, err := os.CreateTemp("", "tty2web-bashrc-*")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create bash audit rcfile")
+	}
+	defer file.Close()
+
+	if _, err := file.WriteString(bashAuditScript()); err != nil {
+		os.Remove(file.Name())
+		return "", errors.Wrap(err, "failed to write bash audit rcfile")
+	}
+
+	log.Printf("Bash command audit hook enabled")
+	return file.Name(), nil
+}
+
+func isPlainBashCommand(command string, argv []string) bool {
+	base := filepath.Base(command)
+	if base != "bash" {
+		log.Printf("Bash command audit hook disabled for non-bash command %q", command)
+		return false
+	}
+	if len(argv) > 0 {
+		log.Printf("Bash command audit hook disabled for bash with arguments")
+		return false
+	}
+	return true
+}
+
+func bashAuditScript() string {
+	return `if [ -f ~/.bashrc ]; then
+	. ~/.bashrc
+fi
+
+__tty2web_audit_debug() {
+	local command=$BASH_COMMAND
+	case "$command" in
+		__tty2web_audit_debug*|trap\ *|PROMPT_COMMAND=*)
+			return 0
+			;;
+	esac
+	if [ -n "$command" ]; then
+		printf '\033]777;tty2web-audit=%s\a' "$(printf '%s' "$command" | base64 | tr -d '\n')"
+	fi
+}
+
+trap '__tty2web_audit_debug' DEBUG
+`
 }
 
 func (lcmd *LocalCommand) Read(p []byte) (n int, err error) {

--- a/backend/localcommand/local_command_unix_test.go
+++ b/backend/localcommand/local_command_unix_test.go
@@ -1,0 +1,59 @@
+//go:build !windows
+// +build !windows
+
+package localcommand
+
+import (
+	"bytes"
+	"encoding/base64"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestIsPlainBashCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		argv    []string
+		want    bool
+	}{
+		{name: "bash", command: "bash", want: true},
+		{name: "bin bash", command: "/bin/bash", want: true},
+		{name: "bash with args", command: "bash", argv: []string{"-c", "echo hi"}, want: false},
+		{name: "sh", command: "sh", want: false},
+		{name: "zsh", command: "zsh", want: false},
+		{name: "k9s", command: "k9s", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPlainBashCommand(tt.command, tt.argv); got != tt.want {
+				t.Fatalf("isPlainBashCommand(%q, %v) = %t, want %t", tt.command, tt.argv, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBashAuditScriptEmitsMarker(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash is not available")
+	}
+
+	auditFile, err := createBashAuditFile("bash", nil)
+	if err != nil {
+		t.Fatalf("createBashAuditFile() error = %v", err)
+	}
+	defer os.Remove(auditFile)
+
+	output, err := exec.Command("bash", "--rcfile", auditFile, "-i", "-c", "echo hello").Output()
+	if err != nil {
+		t.Fatalf("bash audit command error = %v", err)
+	}
+
+	encodedCommand := base64.StdEncoding.EncodeToString([]byte("echo hello"))
+	marker := []byte("\x1b]777;tty2web-audit=" + encodedCommand + "\x07")
+	if !bytes.Contains(output, marker) {
+		t.Fatalf("output does not contain audit marker for echo hello: %q", string(output))
+	}
+}

--- a/webtty/webtty.go
+++ b/webtty/webtty.go
@@ -37,12 +37,51 @@ type WebTTY struct {
 	bufferSize       int
 	writeMutex       sync.Mutex
 	inputBuffer      []byte
+	inputCursor      int
+	commandHistory   []string
+	historyIndex     int
+	historyDraft     string
+	historyActive    bool
 	oauthCookieValue string
 }
 
-// Checks if user is giving UpArrow or DownArrow as input
-func isArrowKey(data []byte) bool {
-	return string(data) == "\x1b[A" || string(data) == "\x1b[B"
+func (wt *WebTTY) setInputBuffer(command string) {
+	wt.inputBuffer = []byte(command)
+	wt.inputCursor = len(wt.inputBuffer)
+}
+
+func (wt *WebTTY) resetHistoryNavigation() {
+	wt.historyActive = false
+	wt.historyDraft = ""
+	wt.historyIndex = len(wt.commandHistory)
+}
+
+func (wt *WebTTY) previousHistory() {
+	if len(wt.commandHistory) == 0 {
+		return
+	}
+	if !wt.historyActive {
+		wt.historyDraft = string(wt.inputBuffer)
+		wt.historyIndex = len(wt.commandHistory)
+		wt.historyActive = true
+	}
+	if wt.historyIndex > 0 {
+		wt.historyIndex--
+	}
+	wt.setInputBuffer(wt.commandHistory[wt.historyIndex])
+}
+
+func (wt *WebTTY) nextHistory() {
+	if !wt.historyActive {
+		return
+	}
+	if wt.historyIndex < len(wt.commandHistory)-1 {
+		wt.historyIndex++
+		wt.setInputBuffer(wt.commandHistory[wt.historyIndex])
+		return
+	}
+	wt.setInputBuffer(wt.historyDraft)
+	wt.resetHistoryNavigation()
 }
 
 // Extract the "username" from JWT token
@@ -223,24 +262,56 @@ func (wt *WebTTY) handleMasterReadEvent(data []byte) error {
 		if wt.shouldVerifyOTP {
 			return nil
 		}
-		if isArrowKey(data[1:]) {
-			return nil
-		}
+		input := data[1:]
+		for i := 0; i < len(input); i++ {
+			b := input[i]
 
-		for _, b := range data[1:] {
+			if b == '\x1b' {
+				if i+2 < len(input) && input[i+1] == '[' {
+					switch input[i+2] {
+					case 'A':
+						wt.previousHistory()
+						i += 2
+						continue
+					case 'B':
+						wt.nextHistory()
+						i += 2
+						continue
+					case 'C':
+						if wt.inputCursor < len(wt.inputBuffer) {
+							wt.inputCursor++
+						}
+						i += 2
+						continue
+					case 'D':
+						if wt.inputCursor > 0 {
+							wt.inputCursor--
+						}
+						i += 2
+						continue
+					}
+				}
+				continue
+			}
+
 			switch b {
 			case '\r', '\n':
 				if len(wt.inputBuffer) > 0 {
 					username := wt.getUsernameFromJWT()
 					log.Printf("User %s executed command: %q", username, string(wt.inputBuffer))
+					wt.commandHistory = append(wt.commandHistory, string(wt.inputBuffer))
 					wt.inputBuffer = nil
+					wt.inputCursor = 0
+					wt.resetHistoryNavigation()
 				}
 			case 127, 8:
-				if len(wt.inputBuffer) > 0 {
-					wt.inputBuffer = wt.inputBuffer[:len(wt.inputBuffer)-1]
+				if wt.inputCursor > 0 {
+					wt.inputBuffer = append(wt.inputBuffer[:wt.inputCursor-1], wt.inputBuffer[wt.inputCursor:]...)
+					wt.inputCursor--
 				}
 			default:
-				wt.inputBuffer = append(wt.inputBuffer, b)
+				wt.inputBuffer = append(wt.inputBuffer[:wt.inputCursor], append([]byte{b}, wt.inputBuffer[wt.inputCursor:]...)...)
+				wt.inputCursor++
 			}
 		}
 

--- a/webtty/webtty.go
+++ b/webtty/webtty.go
@@ -1,10 +1,10 @@
 package webtty
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"log"
 	"strconv"
 	"sync"
@@ -36,53 +36,12 @@ type WebTTY struct {
 
 	bufferSize       int
 	writeMutex       sync.Mutex
-	inputBuffer      []byte
-	inputCursor      int
-	commandHistory   []string
-	historyIndex     int
-	historyDraft     string
-	historyActive    bool
+	auditBuffer      []byte
 	oauthCookieValue string
 }
 
-func (wt *WebTTY) setInputBuffer(command string) {
-	wt.inputBuffer = []byte(command)
-	wt.inputCursor = len(wt.inputBuffer)
-}
-
-func (wt *WebTTY) resetHistoryNavigation() {
-	wt.historyActive = false
-	wt.historyDraft = ""
-	wt.historyIndex = len(wt.commandHistory)
-}
-
-func (wt *WebTTY) previousHistory() {
-	if len(wt.commandHistory) == 0 {
-		return
-	}
-	if !wt.historyActive {
-		wt.historyDraft = string(wt.inputBuffer)
-		wt.historyIndex = len(wt.commandHistory)
-		wt.historyActive = true
-	}
-	if wt.historyIndex > 0 {
-		wt.historyIndex--
-	}
-	wt.setInputBuffer(wt.commandHistory[wt.historyIndex])
-}
-
-func (wt *WebTTY) nextHistory() {
-	if !wt.historyActive {
-		return
-	}
-	if wt.historyIndex < len(wt.commandHistory)-1 {
-		wt.historyIndex++
-		wt.setInputBuffer(wt.commandHistory[wt.historyIndex])
-		return
-	}
-	wt.setInputBuffer(wt.historyDraft)
-	wt.resetHistoryNavigation()
-}
+const auditMarkerPrefix = "\x1b]777;tty2web-audit="
+const auditMarkerSuffix = "\x07"
 
 // Extract the "username" from JWT token
 func (wt *WebTTY) getUsernameFromJWT() string {
@@ -222,6 +181,11 @@ func (wt *WebTTY) sendInitializeMessage() error {
 }
 
 func (wt *WebTTY) handleSlaveReadEvent(data []byte) error {
+	data = wt.filterAuditMarkers(data)
+	if len(data) == 0 {
+		return nil
+	}
+
 	safeMessage := base64.StdEncoding.EncodeToString(data)
 	err := wt.masterWrite(append([]byte{Output}, []byte(safeMessage)...))
 	if err != nil {
@@ -229,6 +193,67 @@ func (wt *WebTTY) handleSlaveReadEvent(data []byte) error {
 	}
 
 	return nil
+}
+
+func (wt *WebTTY) filterAuditMarkers(data []byte) []byte {
+	data = append(wt.auditBuffer, data...)
+	wt.auditBuffer = nil
+
+	var output []byte
+	prefix := []byte(auditMarkerPrefix)
+	suffix := []byte(auditMarkerSuffix)
+
+	for len(data) > 0 {
+		start := bytes.Index(data, prefix)
+		if start == -1 {
+			keep := auditPrefixOverlap(data, prefix)
+			output = append(output, data[:len(data)-keep]...)
+			wt.auditBuffer = append(wt.auditBuffer, data[len(data)-keep:]...)
+			return output
+		}
+
+		output = append(output, data[:start]...)
+		data = data[start+len(prefix):]
+
+		end := bytes.Index(data, suffix)
+		if end == -1 {
+			wt.auditBuffer = append(wt.auditBuffer, prefix...)
+			wt.auditBuffer = append(wt.auditBuffer, data...)
+			return output
+		}
+
+		wt.logAuditCommand(data[:end])
+		data = data[end+len(suffix):]
+	}
+
+	return output
+}
+
+func auditPrefixOverlap(data, prefix []byte) int {
+	max := len(prefix) - 1
+	if len(data) < max {
+		max = len(data)
+	}
+	for n := max; n > 0; n-- {
+		if bytes.Equal(data[len(data)-n:], prefix[:n]) {
+			return n
+		}
+	}
+	return 0
+}
+
+func (wt *WebTTY) logAuditCommand(encoded []byte) {
+	command, err := base64.StdEncoding.DecodeString(string(encoded))
+	if err != nil {
+		log.Printf("Error decoding audit command: %v", err)
+		return
+	}
+	if len(command) == 0 {
+		return
+	}
+
+	username := wt.getUsernameFromJWT()
+	log.Printf("User %s executed command: %q", username, string(command))
 }
 
 func (wt *WebTTY) masterWrite(data []byte) error {
@@ -261,58 +286,6 @@ func (wt *WebTTY) handleMasterReadEvent(data []byte) error {
 		// if OTP enabled and not verified - wait for OTP
 		if wt.shouldVerifyOTP {
 			return nil
-		}
-		input := data[1:]
-		for i := 0; i < len(input); i++ {
-			b := input[i]
-
-			if b == '\x1b' {
-				if i+2 < len(input) && input[i+1] == '[' {
-					switch input[i+2] {
-					case 'A':
-						wt.previousHistory()
-						i += 2
-						continue
-					case 'B':
-						wt.nextHistory()
-						i += 2
-						continue
-					case 'C':
-						if wt.inputCursor < len(wt.inputBuffer) {
-							wt.inputCursor++
-						}
-						i += 2
-						continue
-					case 'D':
-						if wt.inputCursor > 0 {
-							wt.inputCursor--
-						}
-						i += 2
-						continue
-					}
-				}
-				continue
-			}
-
-			switch b {
-			case '\r', '\n':
-				if len(wt.inputBuffer) > 0 {
-					username := wt.getUsernameFromJWT()
-					log.Printf("User %s executed command: %q", username, string(wt.inputBuffer))
-					wt.commandHistory = append(wt.commandHistory, string(wt.inputBuffer))
-					wt.inputBuffer = nil
-					wt.inputCursor = 0
-					wt.resetHistoryNavigation()
-				}
-			case 127, 8:
-				if wt.inputCursor > 0 {
-					wt.inputBuffer = append(wt.inputBuffer[:wt.inputCursor-1], wt.inputBuffer[wt.inputCursor:]...)
-					wt.inputCursor--
-				}
-			default:
-				wt.inputBuffer = append(wt.inputBuffer[:wt.inputCursor], append([]byte{b}, wt.inputBuffer[wt.inputCursor:]...)...)
-				wt.inputCursor++
-			}
 		}
 
 		_, err := wt.slave.Write(data[1:])
@@ -359,8 +332,8 @@ func (wt *WebTTY) handleMasterReadEvent(data []byte) error {
 			if err != nil {
 				return errors.Wrapf(err, "failed to send OTP message")
 			}
-			lockFor := wt.lastFailedOTP.Add(bruteForceTimeout).Sub(time.Now()).Seconds()
-			log.Println(fmt.Sprintf("brute force OTP input prevention triggered - waiting %.3f seconds", lockFor))
+			lockFor := time.Until(wt.lastFailedOTP.Add(bruteForceTimeout)).Seconds()
+			log.Printf("brute force OTP input prevention triggered - waiting %.3f seconds", lockFor)
 			return nil
 		}
 		otp := data[1:]

--- a/webtty/webtty_test.go
+++ b/webtty/webtty_test.go
@@ -56,7 +56,7 @@ func withWebTTY(t *testing.T, f func(tty *WebTTY, master, slave io.ReadWriter)) 
 	master := newBiDirectionalPipe()
 	slave := newBiDirectionalPipe()
 
-	tty, err := New(master.right, slaveBiDirectionalPipeEnd{slave.left}, WithPermitWrite())
+	tty, err := New(master.right, slaveBiDirectionalPipeEnd{slave.left}, "", WithPermitWrite())
 	if err != nil {
 		t.Fatalf("Unexpected error from New(): %s", err)
 	}
@@ -117,6 +117,153 @@ func TestWriteInputFromMaster(t *testing.T) {
 			t.Fatalf("Read() returned `%v` for message `%v`", buf[0:n], message)
 		}
 	})
+}
+
+func TestArrowInputBuffer(t *testing.T) {
+	tty, err := New(&bytes.Buffer{}, slaveBiDirectionalPipeEnd{&bytes.Buffer{}}, "", WithPermitWrite())
+	if err != nil {
+		t.Fatalf("Unexpected error from New(): %s", err)
+	}
+
+	err = tty.handleMasterReadEvent(makeInputMessage([]byte("echo hello\x1b[D\x1b[C")))
+	if err != nil {
+		t.Fatalf("Unexpected error from handleMasterReadEvent(): %s", err)
+	}
+
+	if got, want := string(tty.inputBuffer), "echo hello"; got != want {
+		t.Fatalf("inputBuffer = %q, want %q", got, want)
+	}
+}
+
+func TestInputBufferInsertAtCursor(t *testing.T) {
+	tty, err := New(&bytes.Buffer{}, slaveBiDirectionalPipeEnd{&bytes.Buffer{}}, "", WithPermitWrite())
+	if err != nil {
+		t.Fatalf("Unexpected error from New(): %s", err)
+	}
+
+	err = tty.handleMasterReadEvent(makeInputMessage([]byte("helo\x1b[D\x1b[Dl")))
+	if err != nil {
+		t.Fatalf("Unexpected error from handleMasterReadEvent(): %s", err)
+	}
+
+	if got, want := string(tty.inputBuffer), "hello"; got != want {
+		t.Fatalf("inputBuffer = %q, want %q", got, want)
+	}
+}
+
+func TestInputBufferBackspaceAtCursor(t *testing.T) {
+	tty, err := New(&bytes.Buffer{}, slaveBiDirectionalPipeEnd{&bytes.Buffer{}}, "", WithPermitWrite())
+	if err != nil {
+		t.Fatalf("Unexpected error from New(): %s", err)
+	}
+
+	err = tty.handleMasterReadEvent(makeInputMessage([]byte("hello\x1b[D\x1b[D\x7f")))
+	if err != nil {
+		t.Fatalf("Unexpected error from handleMasterReadEvent(): %s", err)
+	}
+
+	if got, want := string(tty.inputBuffer), "helo"; got != want {
+		t.Fatalf("inputBuffer = %q, want %q", got, want)
+	}
+}
+
+func TestInputBufferCommandHistory(t *testing.T) {
+	tty, err := New(&bytes.Buffer{}, slaveBiDirectionalPipeEnd{&bytes.Buffer{}}, "", WithPermitWrite())
+	if err != nil {
+		t.Fatalf("Unexpected error from New(): %s", err)
+	}
+
+	err = tty.handleMasterReadEvent(makeInputMessage([]byte("echo one\n")))
+	if err != nil {
+		t.Fatalf("Unexpected error from handleMasterReadEvent(): %s", err)
+	}
+
+	if got, want := len(tty.commandHistory), 1; got != want {
+		t.Fatalf("len(commandHistory) = %d, want %d", got, want)
+	}
+	if got, want := tty.commandHistory[0], "echo one"; got != want {
+		t.Fatalf("commandHistory[0] = %q, want %q", got, want)
+	}
+	if got, want := string(tty.inputBuffer), ""; got != want {
+		t.Fatalf("inputBuffer = %q, want %q", got, want)
+	}
+	if got, want := tty.inputCursor, 0; got != want {
+		t.Fatalf("inputCursor = %d, want %d", got, want)
+	}
+}
+
+func TestInputBufferHistoryUp(t *testing.T) {
+	tty, err := New(&bytes.Buffer{}, slaveBiDirectionalPipeEnd{&bytes.Buffer{}}, "", WithPermitWrite())
+	if err != nil {
+		t.Fatalf("Unexpected error from New(): %s", err)
+	}
+
+	for _, command := range []string{"echo one\n", "echo two\n"} {
+		err = tty.handleMasterReadEvent(makeInputMessage([]byte(command)))
+		if err != nil {
+			t.Fatalf("Unexpected error from handleMasterReadEvent(): %s", err)
+		}
+	}
+
+	err = tty.handleMasterReadEvent(makeInputMessage([]byte("\x1b[A")))
+	if err != nil {
+		t.Fatalf("Unexpected error from handleMasterReadEvent(): %s", err)
+	}
+
+	if got, want := string(tty.inputBuffer), "echo two"; got != want {
+		t.Fatalf("inputBuffer = %q, want %q", got, want)
+	}
+	if got, want := tty.inputCursor, len("echo two"); got != want {
+		t.Fatalf("inputCursor = %d, want %d", got, want)
+	}
+}
+
+func TestInputBufferHistoryDownRestoresDraft(t *testing.T) {
+	tty, err := New(&bytes.Buffer{}, slaveBiDirectionalPipeEnd{&bytes.Buffer{}}, "", WithPermitWrite())
+	if err != nil {
+		t.Fatalf("Unexpected error from New(): %s", err)
+	}
+
+	err = tty.handleMasterReadEvent(makeInputMessage([]byte("echo one\n")))
+	if err != nil {
+		t.Fatalf("Unexpected error from handleMasterReadEvent(): %s", err)
+	}
+	err = tty.handleMasterReadEvent(makeInputMessage([]byte("partial")))
+	if err != nil {
+		t.Fatalf("Unexpected error from handleMasterReadEvent(): %s", err)
+	}
+	err = tty.handleMasterReadEvent(makeInputMessage([]byte("\x1b[A\x1b[B")))
+	if err != nil {
+		t.Fatalf("Unexpected error from handleMasterReadEvent(): %s", err)
+	}
+
+	if got, want := string(tty.inputBuffer), "partial"; got != want {
+		t.Fatalf("inputBuffer = %q, want %q", got, want)
+	}
+	if got, want := tty.inputCursor, len("partial"); got != want {
+		t.Fatalf("inputCursor = %d, want %d", got, want)
+	}
+}
+
+func TestInputBufferHistoryUpSubmitsCommand(t *testing.T) {
+	tty, err := New(&bytes.Buffer{}, slaveBiDirectionalPipeEnd{&bytes.Buffer{}}, "", WithPermitWrite())
+	if err != nil {
+		t.Fatalf("Unexpected error from New(): %s", err)
+	}
+
+	for _, input := range []string{"echo one\n", "partial", "\x1b[A\n"} {
+		err = tty.handleMasterReadEvent(makeInputMessage([]byte(input)))
+		if err != nil {
+			t.Fatalf("Unexpected error from handleMasterReadEvent(): %s", err)
+		}
+	}
+
+	if got, want := len(tty.commandHistory), 2; got != want {
+		t.Fatalf("len(commandHistory) = %d, want %d", got, want)
+	}
+	if got, want := tty.commandHistory[1], "echo one"; got != want {
+		t.Fatalf("commandHistory[1] = %q, want %q", got, want)
+	}
 }
 
 func TestWriteFromSlave(t *testing.T) {

--- a/webtty/webtty_test.go
+++ b/webtty/webtty_test.go
@@ -64,9 +64,9 @@ func withWebTTY(t *testing.T, f func(tty *WebTTY, master, slave io.ReadWriter)) 
 	// start webtty in a goroutine and watch for errors
 	ctx, cancel := context.WithCancel(context.Background())
 	var wg sync.WaitGroup
+	runErrors := make(chan error, 1)
 	wg.Add(1)
 	go func() {
-		t.Log("Starting WebTTY.Run()")
 		defer wg.Done()
 		err := tty.Run(ctx)
 		if err != nil {
@@ -75,7 +75,7 @@ func withWebTTY(t *testing.T, f func(tty *WebTTY, master, slave io.ReadWriter)) 
 				// The context is cancelled at the end of the test so ignore this error
 				break
 			default:
-				t.Fatalf("Unexpected error from Run(): %s", err)
+				runErrors <- err
 			}
 		}
 	}()
@@ -91,6 +91,10 @@ func withWebTTY(t *testing.T, f func(tty *WebTTY, master, slave io.ReadWriter)) 
 
 	cancel()
 	wg.Wait()
+	close(runErrors)
+	for err := range runErrors {
+		t.Fatalf("Unexpected error from Run(): %s", err)
+	}
 }
 
 func TestWriteInputFromMaster(t *testing.T) {
@@ -119,150 +123,49 @@ func TestWriteInputFromMaster(t *testing.T) {
 	})
 }
 
-func TestArrowInputBuffer(t *testing.T) {
+func makeAuditMarker(command string) []byte {
+	encoded := base64.StdEncoding.EncodeToString([]byte(command))
+	return []byte(auditMarkerPrefix + encoded + auditMarkerSuffix)
+}
+
+func TestAuditMarkerFilter(t *testing.T) {
 	tty, err := New(&bytes.Buffer{}, slaveBiDirectionalPipeEnd{&bytes.Buffer{}}, "", WithPermitWrite())
 	if err != nil {
 		t.Fatalf("Unexpected error from New(): %s", err)
 	}
 
-	err = tty.handleMasterReadEvent(makeInputMessage([]byte("echo hello\x1b[D\x1b[C")))
-	if err != nil {
-		t.Fatalf("Unexpected error from handleMasterReadEvent(): %s", err)
-	}
+	input := append([]byte("before "), makeAuditMarker("echo one")...)
+	input = append(input, []byte(" after")...)
 
-	if got, want := string(tty.inputBuffer), "echo hello"; got != want {
-		t.Fatalf("inputBuffer = %q, want %q", got, want)
+	if got, want := string(tty.filterAuditMarkers(input)), "before  after"; got != want {
+		t.Fatalf("filterAuditMarkers() = %q, want %q", got, want)
+	}
+	if len(tty.auditBuffer) != 0 {
+		t.Fatalf("auditBuffer = %q, want empty", string(tty.auditBuffer))
 	}
 }
 
-func TestInputBufferInsertAtCursor(t *testing.T) {
+func TestAuditMarkerSplit(t *testing.T) {
 	tty, err := New(&bytes.Buffer{}, slaveBiDirectionalPipeEnd{&bytes.Buffer{}}, "", WithPermitWrite())
 	if err != nil {
 		t.Fatalf("Unexpected error from New(): %s", err)
 	}
 
-	err = tty.handleMasterReadEvent(makeInputMessage([]byte("helo\x1b[D\x1b[Dl")))
-	if err != nil {
-		t.Fatalf("Unexpected error from handleMasterReadEvent(): %s", err)
-	}
+	marker := makeAuditMarker("echo one")
+	first := append([]byte("before "), marker[:10]...)
+	second := append(marker[10:], []byte(" after")...)
 
-	if got, want := string(tty.inputBuffer), "hello"; got != want {
-		t.Fatalf("inputBuffer = %q, want %q", got, want)
+	if got, want := string(tty.filterAuditMarkers(first)), "before "; got != want {
+		t.Fatalf("first filterAuditMarkers() = %q, want %q", got, want)
 	}
-}
-
-func TestInputBufferBackspaceAtCursor(t *testing.T) {
-	tty, err := New(&bytes.Buffer{}, slaveBiDirectionalPipeEnd{&bytes.Buffer{}}, "", WithPermitWrite())
-	if err != nil {
-		t.Fatalf("Unexpected error from New(): %s", err)
+	if len(tty.auditBuffer) == 0 {
+		t.Fatalf("auditBuffer is empty, want partial marker")
 	}
-
-	err = tty.handleMasterReadEvent(makeInputMessage([]byte("hello\x1b[D\x1b[D\x7f")))
-	if err != nil {
-		t.Fatalf("Unexpected error from handleMasterReadEvent(): %s", err)
+	if got, want := string(tty.filterAuditMarkers(second)), " after"; got != want {
+		t.Fatalf("second filterAuditMarkers() = %q, want %q", got, want)
 	}
-
-	if got, want := string(tty.inputBuffer), "helo"; got != want {
-		t.Fatalf("inputBuffer = %q, want %q", got, want)
-	}
-}
-
-func TestInputBufferCommandHistory(t *testing.T) {
-	tty, err := New(&bytes.Buffer{}, slaveBiDirectionalPipeEnd{&bytes.Buffer{}}, "", WithPermitWrite())
-	if err != nil {
-		t.Fatalf("Unexpected error from New(): %s", err)
-	}
-
-	err = tty.handleMasterReadEvent(makeInputMessage([]byte("echo one\n")))
-	if err != nil {
-		t.Fatalf("Unexpected error from handleMasterReadEvent(): %s", err)
-	}
-
-	if got, want := len(tty.commandHistory), 1; got != want {
-		t.Fatalf("len(commandHistory) = %d, want %d", got, want)
-	}
-	if got, want := tty.commandHistory[0], "echo one"; got != want {
-		t.Fatalf("commandHistory[0] = %q, want %q", got, want)
-	}
-	if got, want := string(tty.inputBuffer), ""; got != want {
-		t.Fatalf("inputBuffer = %q, want %q", got, want)
-	}
-	if got, want := tty.inputCursor, 0; got != want {
-		t.Fatalf("inputCursor = %d, want %d", got, want)
-	}
-}
-
-func TestInputBufferHistoryUp(t *testing.T) {
-	tty, err := New(&bytes.Buffer{}, slaveBiDirectionalPipeEnd{&bytes.Buffer{}}, "", WithPermitWrite())
-	if err != nil {
-		t.Fatalf("Unexpected error from New(): %s", err)
-	}
-
-	for _, command := range []string{"echo one\n", "echo two\n"} {
-		err = tty.handleMasterReadEvent(makeInputMessage([]byte(command)))
-		if err != nil {
-			t.Fatalf("Unexpected error from handleMasterReadEvent(): %s", err)
-		}
-	}
-
-	err = tty.handleMasterReadEvent(makeInputMessage([]byte("\x1b[A")))
-	if err != nil {
-		t.Fatalf("Unexpected error from handleMasterReadEvent(): %s", err)
-	}
-
-	if got, want := string(tty.inputBuffer), "echo two"; got != want {
-		t.Fatalf("inputBuffer = %q, want %q", got, want)
-	}
-	if got, want := tty.inputCursor, len("echo two"); got != want {
-		t.Fatalf("inputCursor = %d, want %d", got, want)
-	}
-}
-
-func TestInputBufferHistoryDownRestoresDraft(t *testing.T) {
-	tty, err := New(&bytes.Buffer{}, slaveBiDirectionalPipeEnd{&bytes.Buffer{}}, "", WithPermitWrite())
-	if err != nil {
-		t.Fatalf("Unexpected error from New(): %s", err)
-	}
-
-	err = tty.handleMasterReadEvent(makeInputMessage([]byte("echo one\n")))
-	if err != nil {
-		t.Fatalf("Unexpected error from handleMasterReadEvent(): %s", err)
-	}
-	err = tty.handleMasterReadEvent(makeInputMessage([]byte("partial")))
-	if err != nil {
-		t.Fatalf("Unexpected error from handleMasterReadEvent(): %s", err)
-	}
-	err = tty.handleMasterReadEvent(makeInputMessage([]byte("\x1b[A\x1b[B")))
-	if err != nil {
-		t.Fatalf("Unexpected error from handleMasterReadEvent(): %s", err)
-	}
-
-	if got, want := string(tty.inputBuffer), "partial"; got != want {
-		t.Fatalf("inputBuffer = %q, want %q", got, want)
-	}
-	if got, want := tty.inputCursor, len("partial"); got != want {
-		t.Fatalf("inputCursor = %d, want %d", got, want)
-	}
-}
-
-func TestInputBufferHistoryUpSubmitsCommand(t *testing.T) {
-	tty, err := New(&bytes.Buffer{}, slaveBiDirectionalPipeEnd{&bytes.Buffer{}}, "", WithPermitWrite())
-	if err != nil {
-		t.Fatalf("Unexpected error from New(): %s", err)
-	}
-
-	for _, input := range []string{"echo one\n", "partial", "\x1b[A\n"} {
-		err = tty.handleMasterReadEvent(makeInputMessage([]byte(input)))
-		if err != nil {
-			t.Fatalf("Unexpected error from handleMasterReadEvent(): %s", err)
-		}
-	}
-
-	if got, want := len(tty.commandHistory), 2; got != want {
-		t.Fatalf("len(commandHistory) = %d, want %d", got, want)
-	}
-	if got, want := tty.commandHistory[1], "echo one"; got != want {
-		t.Fatalf("commandHistory[1] = %q, want %q", got, want)
+	if len(tty.auditBuffer) != 0 {
+		t.Fatalf("auditBuffer = %q, want empty", string(tty.auditBuffer))
 	}
 }
 


### PR DESCRIPTION
Re enabled terminal arrow keys and cleaned up audit logging so edited commands are logged correctly.